### PR TITLE
add cmake TVDISPLAY option to enable TotalView C++View debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Configuration Options
 OPTION(MPI "Enable MPI operations for spaths" ON)
 OPTION(SPATH_LINK_STATIC "Default to static linking? (Needed for Cray)" OFF)
+OPTION(TVDISPLAY "Whether to compile tv_data_display.c for debugging with TotalView C++View" OFF)
 
 # Find Packages & Files
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,10 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
 # LIB SPATH #
 ###########
 
+IF(TVDISPLAY)
+    ADD_DEFINITIONS(-DHAVE_TV)
+ENDIF(TVDISPLAY)
+
 # Install header files
 LIST(APPEND libspath_install_headers
 	spath.h
@@ -19,6 +23,10 @@ LIST(APPEND libspath_noMPI_srcs
     spath.c
     spath_util.c
 )
+IF(TVDISPLAY)
+    LIST(APPEND libspath_noMPI_srcs tv_data_display.c)
+ENDIF(TVDISPLAY)
+
 LIST(APPEND libspath_srcs
     spath.c
     spath_util.c
@@ -26,7 +34,9 @@ LIST(APPEND libspath_srcs
 IF(MPI)
     LIST(APPEND libspath_srcs spath_mpi.c)
 ENDIF(MPI)
-
+IF(TVDISPLAY)
+    LIST(APPEND libspath_srcs tv_data_display.c)
+ENDIF(TVDISPLAY)
 
 # SPATH Library
 ADD_LIBRARY(spath_o OBJECT ${libspath_srcs})

--- a/src/spath.c
+++ b/src/spath.c
@@ -1462,8 +1462,7 @@ int spath_is_writeable(const spath* file)
 }
 #endif
 
-#if 0
-#ifndef HIDE_TV
+#ifdef HAVE_TV
 /*
 =========================================
 Pretty print for TotalView debug window
@@ -1487,12 +1486,15 @@ static int TV_ttf_display_type(const spath* path)
     return TV_ttf_format_ok;
   }
 
+  /* when last tested, this string needs to be dynamically allocated
+   * but not freed in order for TV to dispaly the correct value */
   /* print path in string form */
+  //char str[2048];
+  //spath_strcpy(str, sizeof(str), path);
   char* str = spath_strdup(path);
   TV_ttf_add_row("path", TV_ttf_type_ascii_string, str);
-  spath_free(&str);
+  //spath_free(&str);
 
   return TV_ttf_format_ok;
 }
-#endif /* HIDE_TV */
-#endif
+#endif /* HAVE_TV */

--- a/src/spath.h
+++ b/src/spath.h
@@ -55,7 +55,7 @@ typedef struct spath_elem_struct {
 } spath_elem;
 
 /** define the structure for a path object */
-typedef struct {
+typedef struct spath_struct {
   int components;      /* number of components in path */
   size_t chars;        /* number of chars in path */
   spath_elem* head; /* pointer to first element */

--- a/src/tv_data_display.c
+++ b/src/tv_data_display.c
@@ -1,0 +1,297 @@
+/* 
+ * $Header: /home/tv/src/debugger/src/datadisp/tv_data_display.c,v 1.5 2010/10/04 04:02:19 anb Exp $
+ * $Locker:  $
+
+   Copyright (c) 2010, Rogue Wave Software, Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+ * Update log
+ *
+ * Sep 27 2010 ANB: lots of changes as part of totalview/12314.
+ *                  Reworked to reduce the dependencies on outside
+ *                  entities, both at compile and also at runtime.
+ *                  Adjusted the naming scheme.
+ * Jan 28 2010 SJT: Bug 12100, bump base size to 16K and recognize if it is
+ *                  resized further.
+ * Sep 24 2009 SJT: Remove pre/post callback to reduce function call overhead.
+ * Jul 1  2009 SJT: Created.
+ *
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "tv_data_display.h"
+
+#include <stdio.h>
+#include <stddef.h>             /* for size_t */
+
+#define DATA_FORMAT_BUFFER_SIZE 16384
+#define TV_FORMAT_INACTIVE 0
+#define TV_FORMAT_FIRST_CALL 1
+#define TV_FORMAT_APPEND_CALL 2
+
+volatile int TV_ttf_data_format_control      = TV_FORMAT_INACTIVE;
+int          TV_ttf_data_display_api_version = TV_TTF_DATA_DISPLAY_API_VERSION;
+   
+/* TV_ttf_data_format_buffer should not be static for icc 11, and others */
+char TV_ttf_data_format_buffer[DATA_FORMAT_BUFFER_SIZE];
+static char *TV_ttf_data_buffer_ptr = TV_ttf_data_format_buffer;
+
+static const char   digits []  = "0123456789abcdefghijklmnopqrstuvwxyz";
+static const size_t base_bound = sizeof ( digits );
+
+/* ************************************************************************ */
+
+int
+TV_ttf_is_format_result_ok ( TV_ttf_format_result fr )
+{
+  int  ret_val;
+
+  switch ( fr )
+    {
+    case TV_ttf_format_ok:
+    case TV_ttf_format_ok_elide:
+      ret_val = 1;
+      break;
+    default:
+      ret_val = 0;
+      break;
+    }
+  return ret_val;
+} /* TV_ttf_is_format_result_ok */
+
+/* ************************************************************************ */
+
+static
+void *
+my_zeroit ( void *s, size_t n )
+{
+  char *cp = (char *) s;
+
+  /* not the most efficient of solutions.  What we should do is   */
+  /* do the assugnments in units of int or long.  The problem     */
+  /* with that is ensuring that the alignments of the assignments */
+  /* are correct.  The difficulty with that is doing arithmetic   */
+  /* on pointers in a portable manner.                            */
+  while ( n > 0 )
+    {
+      *cp++ = 0;
+      n--;
+    }
+
+  return s;
+} /* my_zeroit */
+
+static
+char *
+my_strpbrk ( const char *str, const char *accept )
+{
+  char  *ret_val = NULL;
+  char  *s, *t;
+
+  for ( s = (char *) str; (*s) && (! ret_val); s++ )
+    {
+      for ( t = (char *) accept; (*t) && (! ret_val); t++ )
+        {
+          if ( *s == *t )
+            ret_val = s;
+        }
+    }
+
+  return ret_val;
+} /* my_strpbrk */
+
+static
+int
+marshal_string ( char *buffer, size_t len, const char *s,
+                                                 char **nbuffer, size_t *nlen )
+{
+  int   ret_val = 0;
+  char *cursor  = buffer;
+
+  while ( *s )
+    {
+      ret_val++;
+      if ( len > 1 )
+        {
+          *cursor++ = *s++;
+          len--;
+        }
+    }
+  if ( len > 0 )
+    *cursor = '\0';
+
+  if ( nbuffer )
+    *nbuffer = cursor;
+  if ( nlen )
+    *nlen = len;
+
+  return ret_val;
+} /* marshal_string */
+
+static
+int
+marshal_unsigned_body ( char *buffer, size_t len, size_t val, int base,
+                                                char **nbuffer, size_t *nlen )
+{
+
+  int     ret_val = 0;
+  size_t  q, r;
+  char    digit [ 2 ];
+  char   *my_buffer  = buffer;
+  size_t  my_len     = len;
+
+  if ( val < base )
+    {
+      r = val;
+    }
+  else
+    {
+      q        = val / base;
+      r        = val - (q * base);
+      ret_val += marshal_unsigned_body ( buffer, len, q, base,
+                                                     &my_buffer, &my_len );
+    }
+  digit [ 0 ]  = digits [ r ];
+  digit [ 1 ]  = '\0';
+  ret_val     += marshal_string ( my_buffer, my_len, digit, nbuffer, nlen );
+
+  return ret_val;
+} /* marshal_unsigned_body */
+
+static
+int
+marshal_unsigned ( char *buffer, size_t len, size_t val, int base,
+                                                char **nbuffer, size_t *nlen )
+{
+  int     ret_val = 0;
+
+  if ( 0 == base )
+    base = 10;
+  if ( base < base_bound )
+    ret_val = marshal_unsigned_body ( buffer, len, val, base, nbuffer, nlen );
+  else
+    ret_val = -1;
+
+  return ret_val;
+} /* marshal_unsigned */
+
+static
+int
+marshal_hex ( char *buffer, size_t len, size_t hex_val,
+                                              char **nbuffer, size_t *nlen  )
+{
+  int     ret_val = 0;
+  char   *my_buffer;
+  size_t  my_len;
+
+  ret_val += marshal_string ( buffer, len, "0x", &my_buffer, &my_len );
+  ret_val += marshal_unsigned ( my_buffer, my_len, hex_val, 16, nbuffer, nlen );
+
+  return ret_val;
+} /* marshal_hex */
+
+static
+int
+marshal_row ( char *buffer, size_t len, const char   *field_name,
+                                        const char   *type_name,
+                                        const void   *value,
+                                        char        **nbuffer,
+                                        size_t       *nlen )
+{
+  int     ret_val = 0;
+  char   *my_buffer;
+  size_t  my_len;
+
+  ret_val += marshal_string ( buffer, len, field_name, &my_buffer, &my_len );
+  ret_val += marshal_string ( my_buffer, my_len, "\t", &my_buffer, &my_len );
+  ret_val += marshal_string ( my_buffer, my_len, type_name, &my_buffer, &my_len );
+  ret_val += marshal_string ( my_buffer, my_len, "\t", &my_buffer, &my_len );
+  ret_val += marshal_hex ( my_buffer, my_len, (size_t) value, &my_buffer, &my_len );
+  ret_val += marshal_string ( my_buffer, my_len, "\n", nbuffer, nlen );
+
+  return ret_val;
+} /* marshal_row */
+
+int TV_ttf_add_row(const char *field_name,
+                   const char *type_name,
+                   const void *value)
+{
+  size_t remaining;
+  int out;
+
+  /*
+  printf ( "TV_ttf_add_row: on entry TV_ttf_data_format_control == %d\n", TV_ttf_data_format_control );
+  */
+
+  /* Called at the wrong time */
+  if (TV_ttf_data_format_control == TV_FORMAT_INACTIVE)
+    return TV_ttf_ec_not_active;
+    
+  if (my_strpbrk(field_name, "\n\t") != NULL)
+    return TV_ttf_ec_invalid_characters;
+
+  if (my_strpbrk(type_name, "\n\t") != NULL)
+    return TV_ttf_ec_invalid_characters;
+
+  if (TV_ttf_data_format_control == TV_FORMAT_FIRST_CALL)
+    {
+      /* Zero out the buffer to avoid confusion, and set the write point 
+         to the top of the buffer. */
+
+      my_zeroit(TV_ttf_data_format_buffer, sizeof (TV_ttf_data_format_buffer));
+      TV_ttf_data_buffer_ptr     = TV_ttf_data_format_buffer;
+      TV_ttf_data_format_control = TV_FORMAT_APPEND_CALL;
+    }
+        
+  remaining = TV_ttf_data_buffer_ptr +
+              DATA_FORMAT_BUFFER_SIZE - TV_ttf_data_format_buffer;
+  
+/*
+  out = snprintf(TV_ttf_data_buffer_ptr, 
+                 remaining, "%s\t%s\t%p\n", 
+                 field_name, type_name, value);
+*/
+  out = marshal_row ( TV_ttf_data_buffer_ptr, remaining,
+                      field_name, type_name, value, 0, 0 );
+  
+  if (out < 1)
+    return TV_ttf_ec_buffer_exhausted;
+    
+  TV_ttf_data_buffer_ptr += out;
+  
+  return 0;
+} /* TV_ttf_add_row */
+
+void TV_ttf_pre_display_callback(void)
+{
+  TV_ttf_data_format_control = TV_FORMAT_FIRST_CALL;
+}
+
+void TV_ttf_post_display_callback(void)
+{
+  TV_ttf_data_format_control = TV_FORMAT_INACTIVE;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/tv_data_display.h
+++ b/src/tv_data_display.h
@@ -1,0 +1,91 @@
+/* 
+ * $Header: /home/tv/src/debugger/src/datadisp/tv_data_display.h,v 1.5 2010/10/04 04:02:19 anb Exp $
+ * $Locker:  $
+
+   Copyright (c) 2010, Rogue Wave Software, Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy
+   of this software and associated documentation files (the "Software"), to deal
+   in the Software without restriction, including without limitation the rights
+   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+   copies of the Software, and to permit persons to whom the Software is
+   furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+   THE SOFTWARE.
+
+ * Update log
+ *
+ * Sep 27 2010 ANB: reworked as part of totalview/12314
+ * Jun 17 2010 JVD: Added TV_elide_row.
+ * Sep 25 2009 SJT: Add idempotence header.
+ * Jul 1  2009 SJT: Created.
+ *
+ */
+
+#ifndef TV_DATA_DISPLAY_H_INCLUDED
+#define TV_DATA_DISPLAY_H_INCLUDED 1
+
+#define TV_TTF_DATA_DISPLAY_API_VERSION 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* TV_ttf_display_type should return one of these values  */
+enum TV_ttf_format_result
+  {
+    TV_ttf_format_ok,       /* Type is known, and successfully converted */
+    TV_ttf_format_ok_elide, /* as TV_ttf_format_ok, but elide type       */
+    TV_ttf_format_failed,   /* Type is known, but could not convert it */
+    TV_ttf_format_raw,      /* Just display it as a regular type for now */
+    TV_ttf_format_never     /* Don't know about this type, and please don't ask again */
+  };
+typedef enum TV_ttf_format_result TV_ttf_format_result;
+
+/* TV_ttf_add_row returns one of these values */
+enum TV_ttf_error_codes
+  {
+    TV_ttf_ec_ok  = 0,          /* operation succeeded                 */
+    TV_ttf_ec_not_active,
+    TV_ttf_ec_invalid_characters,
+    TV_ttf_ec_buffer_exhausted
+  };
+typedef enum TV_ttf_error_codes TV_ttf_error_codes;
+
+#define TV_ttf_type_ascii_string "$string"
+#define TV_ttf_type_int "$int"
+#if 0
+#define TV_elide_row ""     /* field_name to use when row elision is desired */
+#endif
+
+/* returns logical true (non-zero) if the TV_ttf_format_result fr represents
+   a format result that indicates success
+*/
+extern int TV_ttf_is_format_result_ok ( TV_ttf_format_result fr );
+
+/* 
+                  TV_ttf_ec_ok: Success
+          TV_ttf_ec_not_active: Called with no active callback to
+	                        TV_ttf_display_type
+  TV_ttf_ec_invalid_characters: field_name or type_name has illegal characters
+    TV_ttf_ec_buffer_exhausted: No more room left for display data
+*/
+extern int TV_ttf_add_row(const char *field_name,
+                          const char *type_name,
+                          const void *value);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Compile in ``tv_data_display.c`` to display spath objects under TotalView's C++View.

This is not on by default due to https://github.com/LLNL/scr/issues/290