### PR TITLE
Incremental release v0.1.0

### DIFF
--- a/src/spath.h
+++ b/src/spath.h
@@ -12,7 +12,7 @@ extern "C" {
 #define SPATH_SUCCESS (0)
 #define SPATH_FAILURE (1)
 
-#define SPATH_VERSION "0.0.2"
+#define SPATH_VERSION "0.1.0"
 
 /* TODO: for formatted strings, use special %| character (or something
  * similar) to denote directories in portable way */


### PR DESCRIPTION
Update `SPATH_VERSION` to v0.1.0 for tagging a new release in preparation for SCR v3.0rc2.
Addresses item three of #18.